### PR TITLE
E rest pedal fixed

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,7 +80,7 @@ public class RobotContainer {
   private Supplier<Boolean> m_elevUp = () -> false;
   private Supplier<Boolean> m_elevDown = () -> false;
 
-  private static final double LEFT_PEDAL_THRESHOLD = -0.6;
+  private static final double LEFT_PEDAL_THRESHOLD = 0.2;
   private static final double RIGHT_PEDAL_THRESHOLD = -0.8;
   private static final double MIDDLE_PEDAL_THRESHOLD = -0.6;
 
@@ -368,7 +368,7 @@ public class RobotContainer {
     Trigger trigger_povUp = secondaryController.povUp();
     Trigger trigger_povDown = secondaryController.povDown();
 
-    Trigger trigger_leftPedal = pedals.axisGreaterThan(1, LEFT_PEDAL_THRESHOLD);
+    Trigger trigger_leftPedal = pedals.axisGreaterThan(0, LEFT_PEDAL_THRESHOLD);
     Trigger trigger_middlePedal = pedals.axisGreaterThan(2, MIDDLE_PEDAL_THRESHOLD);
     Trigger trigger_rightPedal = pedals.axisGreaterThan(3, RIGHT_PEDAL_THRESHOLD);
 
@@ -424,7 +424,7 @@ public class RobotContainer {
     Trigger trigger_algaeClutch = secondaryController.povLeft();
     Trigger trigger_coralClutch = secondaryController.povDown();
 
-    Trigger trigger_eRestPedal = pedals.axisGreaterThan(1, LEFT_PEDAL_THRESHOLD);
+    Trigger trigger_eRestPedal = pedals.axisGreaterThan(0, LEFT_PEDAL_THRESHOLD);
     Trigger trigger_algaeClutchPedal = pedals.axisGreaterThan(2, MIDDLE_PEDAL_THRESHOLD);
     Trigger trigger_coralClutchPedal = pedals.axisGreaterThan(3, RIGHT_PEDAL_THRESHOLD);
 


### PR DESCRIPTION
Adjust the LEFT_PEDAL_THRESHOLD to account for the different range of travel after HW changes were done. Instead of traveling from -1 to 1 like the other pedals, the left pedal travels from 0 to 1.  Thus the new threshold we will trigger on is +0.2.

Also, the port number changed from 1 to 0.